### PR TITLE
Adding Alecto	SMART-HEAT10 TRV (#1067)

### DIFF
--- a/zhaquirks/tuya/valve.py
+++ b/zhaquirks/tuya/valve.py
@@ -893,6 +893,7 @@ class SiterwellGS361_Type1(TuyaThermostat):
             ("_TYST11_hhrtiq0x", "hrtiq0x"),
             ("_TYST11_ps5v5jor", "s5v5jor"),
             ("_TYST11_owwdxjbx", "wwdxjbx"),
+            ("_TYST11_8daqwrsj", "daqwrsj"),
         ],
         ENDPOINTS: {
             1: {
@@ -936,6 +937,7 @@ class SiterwellGS361_Type2(TuyaThermostat):
             ("_TZE200_hhrtiq0x", "TS0601"),
             ("_TZE200_ps5v5jor", "TS0601"),
             ("_TZE200_owwdxjbx", "TS0601"),
+            ("_TZE200_8daqwrsj", "TS0601"),
         ],
         ENDPOINTS: {
             1: {


### PR DESCRIPTION
* Adding Alecto	SMART-HEAT10 TRV

Adding _TYST11_8daqwrsj daqwrsj and _TZE200_8daqwrsj TS0601
Renaming valve.py to ts0601_trv.py so it matching the "ts0601" family devices (tuya MCU with DP cluster).

* Redoing renaming then its braking over 60 tests